### PR TITLE
Added configuration for displaying images

### DIFF
--- a/app/views/courses/_course.html.haml
+++ b/app/views/courses/_course.html.haml
@@ -5,6 +5,7 @@
   -if course.avatar.attached?
     .card-img-top
       = image_tag course.avatar, height: "200px", width: "100%"
+      -# = image_tag course.avatar.variant(resize_to_limit: [100, 100])
   .card-body
     %small= simple_format(course.short_description)
   .card-footer

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,7 @@ module RubyGemsBootcamp
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
+    config.active_storage.variant_processor = :mini_magick
 
     # Configuration for the application, engines, and railties goes here.
     #


### PR DESCRIPTION
**Description**

This PR is focus on lesson 117, here we setup the aws cors using this a [JSON](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ManageCorsUsing.html) like this one : 
```
[
    {
        "AllowedHeaders": [
            "*"
        ],
        "AllowedMethods": [
            "PUT",
            "POST",
            "DELETE"
        ],
        "AllowedOrigins": [
            "http://www.example1.com"
        ],
        "ExposeHeaders": []
    },
    {
        "AllowedHeaders": [
            "*"
        ],
        "AllowedMethods": [
            "PUT",
            "POST",
            "DELETE"
        ],
        "AllowedOrigins": [
            "http://www.example2.com"
        ],
        "ExposeHeaders": []
    },
    {
        "AllowedHeaders": [],
        "AllowedMethods": [
            "GET"
        ],
        "AllowedOrigins": [
            "*"
        ],
        "ExposeHeaders": []
    }
]
```
We also need to install [imagemagick](https://imagemagick.org/script/download.php) to make it appear locally cause if we don't install it will display the following error:
<img width="782" alt="Screenshot 2025-01-11 at 12 56 34 AM" src="https://github.com/user-attachments/assets/bc7a0cbb-759e-46b4-8da3-54077470cf6a" />

So after doing the configurations on AWS it works as expected.
